### PR TITLE
crap: add test coverage for CRAP map and raw reconciliation

### DIFF
--- a/pkg/maps/crap/crap_privileged_test.go
+++ b/pkg/maps/crap/crap_privileged_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package crap
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func TestPrivilegedCrapMap(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	logger := hivetest.Logger(t)
+	bpf.CheckOrMountFS(logger, "")
+	require.NoError(t, rlimit.RemoveMemlock())
+
+	crapMap := CreatePrivatePolicyMap(hivetest.Lifecycle(t), nil)
+
+	dstIP1 := netip.MustParseAddr("1.1.1.1")
+	dstIP2 := netip.MustParseAddr("2.2.2.2")
+	podIP1 := netip.MustParseAddr("10.0.0.1")
+	podIP2 := netip.MustParseAddr("10.0.0.2")
+
+	require.NoError(t, crapMap.UpdateCrapMapping(dstIP1, podIP1))
+	require.NoError(t, crapMap.Update(NewKey(dstIP2), NewVal(podIP2)))
+
+	val, err := crapMap.Lookup(&CrapKey{DestIP: NewKey(dstIP1).DestIP})
+	require.NoError(t, err)
+	assert.True(t, val.Match(podIP1))
+
+	val, err = crapMap.Lookup(&CrapKey{DestIP: NewKey(dstIP2).DestIP})
+	require.NoError(t, err)
+	assert.True(t, val.Match(podIP2))
+
+	entries := map[CrapKey]CrapVal{}
+	require.NoError(t, crapMap.IterateWithCallback(func(key *CrapKey, val *CrapVal) {
+		entries[*key] = *val
+	}))
+	assert.Len(t, entries, 2)
+	entry1 := entries[NewKey(dstIP1)]
+	entry2 := entries[NewKey(dstIP2)]
+	assert.True(t, (&entry1).Match(podIP1))
+	assert.True(t, (&entry2).Match(podIP2))
+
+	require.NoError(t, crapMap.RemoveCrapMapping(dstIP1))
+	require.NoError(t, crapMap.Delete(&CrapKey{DestIP: NewKey(dstIP2).DestIP}))
+
+	_, err = crapMap.Lookup(&CrapKey{DestIP: NewKey(dstIP1).DestIP})
+	assert.ErrorIs(t, err, ebpf.ErrKeyNotExist)
+
+	_, err = crapMap.Lookup(&CrapKey{DestIP: NewKey(dstIP2).DestIP})
+	assert.ErrorIs(t, err, ebpf.ErrKeyNotExist)
+}

--- a/pkg/maps/crap/crap_test.go
+++ b/pkg/maps/crap/crap_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package crap
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/hive"
+)
+
+func TestCell(t *testing.T) {
+	err := hive.New(Cell).Populate(hivetest.Logger(t))
+	assert.NoError(t, err)
+}
+
+func TestNewKey(t *testing.T) {
+	addr := netip.MustParseAddr("10.0.0.1")
+
+	key := NewKey(addr)
+
+	assert.True(t, key.Match(addr))
+	assert.Equal(t, "10.0.0.1", key.String())
+}
+
+func TestNewVal(t *testing.T) {
+	addr := netip.MustParseAddr("192.168.1.10")
+
+	val := NewVal(addr)
+
+	assert.True(t, (&val).Match(addr))
+	assert.Equal(t, "pod_ip=192.168.1.10", (&val).String())
+}
+
+func TestCrapKeyNew(t *testing.T) {
+	key := &CrapKey{}
+	assert.IsType(t, &CrapKey{}, key.New())
+}
+
+func TestCrapValNew(t *testing.T) {
+	val := &CrapVal{}
+	assert.IsType(t, &CrapVal{}, val.New())
+}
+
+func TestMatchRejectsOtherAddress(t *testing.T) {
+	key := NewKey(netip.MustParseAddr("10.0.0.1"))
+	val := NewVal(netip.MustParseAddr("10.0.0.2"))
+
+	assert.False(t, key.Match(netip.MustParseAddr("10.0.0.3")))
+	assert.False(t, (&val).Match(netip.MustParseAddr("10.0.0.4")))
+}

--- a/pkg/raw/raw_privileged_test.go
+++ b/pkg/raw/raw_privileged_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package raw
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/maps/crap"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func countMapEntries(t *testing.T, m *crap.CrapMap) int {
+	t.Helper()
+	count := 0
+	require.NoError(t, m.IterateWithCallback(func(k *crap.CrapKey, v *crap.CrapVal) {
+		count++
+	}))
+	return count
+}
+
+func TestPrivilegedUpdateRawRules(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	logger := hivetest.Logger(t)
+	bpf.CheckOrMountFS(logger, "")
+	require.NoError(t, rlimit.RemoveMemlock())
+
+	crapMap := crap.CreatePrivatePolicyMap(hivetest.Lifecycle(t), nil)
+
+	existingKeepDst := netip.MustParseAddr("203.0.113.1")
+	existingKeepPod := netip.MustParseAddr("10.0.0.1")
+	staleDst := netip.MustParseAddr("203.0.113.2")
+	stalePod := netip.MustParseAddr("10.0.0.2")
+	newDst := netip.MustParseAddr("203.0.113.3")
+	newPod := netip.MustParseAddr("10.0.0.3")
+
+	manager := &CrapManager{
+		logger: logger,
+		bpfmap: crapMap,
+	}
+
+	// Seed the map with two entries before reconciliation.
+	require.NoError(t, crapMap.Update(crap.NewKey(existingKeepDst), crap.NewVal(existingKeepPod)))
+	require.NoError(t, crapMap.Update(crap.NewKey(staleDst), crap.NewVal(stalePod)))
+
+	t.Run("keep, add, and remove", func(t *testing.T) {
+		manager.updateRawRules(map[crap.CrapKey]crap.CrapVal{
+			crap.NewKey(existingKeepDst): crap.NewVal(existingKeepPod),
+			crap.NewKey(newDst):          crap.NewVal(newPod),
+		})
+
+		assert.Equal(t, 2, countMapEntries(t, crapMap))
+
+		val, err := crapMap.Lookup(&crap.CrapKey{DestIP: crap.NewKey(existingKeepDst).DestIP})
+		require.NoError(t, err)
+		assert.True(t, val.Match(existingKeepPod))
+
+		val, err = crapMap.Lookup(&crap.CrapKey{DestIP: crap.NewKey(newDst).DestIP})
+		require.NoError(t, err)
+		assert.True(t, val.Match(newPod))
+
+		_, err = crapMap.Lookup(&crap.CrapKey{DestIP: crap.NewKey(staleDst).DestIP})
+		assert.ErrorIs(t, err, ebpf.ErrKeyNotExist)
+	})
+
+	t.Run("update existing entry value", func(t *testing.T) {
+		updatedPod := netip.MustParseAddr("10.0.0.99")
+		manager.updateRawRules(map[crap.CrapKey]crap.CrapVal{
+			crap.NewKey(existingKeepDst): crap.NewVal(updatedPod),
+		})
+
+		assert.Equal(t, 1, countMapEntries(t, crapMap))
+
+		val, err := crapMap.Lookup(&crap.CrapKey{DestIP: crap.NewKey(existingKeepDst).DestIP})
+		require.NoError(t, err)
+		assert.True(t, val.Match(updatedPod))
+	})
+
+	t.Run("empty desired clears all entries", func(t *testing.T) {
+		manager.updateRawRules(map[crap.CrapKey]crap.CrapVal{})
+		assert.Equal(t, 0, countMapEntries(t, crapMap))
+	})
+}

--- a/pkg/raw/raw_test.go
+++ b/pkg/raw/raw_test.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package raw
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/maps/crap"
+)
+
+func TestMatchesPodLabels(t *testing.T) {
+	tests := []struct {
+		name      string
+		selector  map[string]string
+		podLabels map[string]string
+		want      bool
+	}{
+		{
+			name:      "exact match",
+			selector:  map[string]string{"app": "web"},
+			podLabels: map[string]string{"app": "web"},
+			want:      true,
+		},
+		{
+			name:      "selector is subset",
+			selector:  map[string]string{"app": "web"},
+			podLabels: map[string]string{"app": "web", "env": "prod"},
+			want:      true,
+		},
+		{
+			name:      "value mismatch",
+			selector:  map[string]string{"app": "web"},
+			podLabels: map[string]string{"app": "api"},
+			want:      false,
+		},
+		{
+			name:      "empty selector",
+			selector:  map[string]string{},
+			podLabels: map[string]string{"app": "web"},
+			want:      false,
+		},
+		{
+			name:      "nil selector",
+			selector:  nil,
+			podLabels: map[string]string{"app": "web"},
+			want:      false,
+		},
+		{
+			name:      "selector superset of pod labels",
+			selector:  map[string]string{"app": "web", "env": "prod"},
+			podLabels: map[string]string{"app": "web"},
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &serviceMetadata{labels: tt.selector}
+			assert.Equal(t, tt.want, svc.matchesPodLabels(tt.podLabels))
+		})
+	}
+}
+
+func TestGetServiceMetadata(t *testing.T) {
+	svc := &slim_corev1.Service{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			UID: types.UID("service-1"),
+		},
+		Spec: slim_corev1.ServiceSpec{
+			Selector:    map[string]string{"app": "web"},
+			ExternalIPs: []string{"192.0.2.10", "not-an-ip", "192.0.2.11"},
+		},
+	}
+
+	meta, err := getServiceMetadata(svc)
+	require.NoError(t, err)
+	require.Len(t, meta.vip, 2)
+	assert.Equal(t, serviceID("service-1"), meta.id)
+	assert.Equal(t, map[string]string{"app": "web"}, meta.labels)
+	assert.Equal(t, netip.MustParseAddr("192.0.2.10"), meta.vip[0])
+	assert.Equal(t, netip.MustParseAddr("192.0.2.11"), meta.vip[1])
+}
+
+func TestBuildRules(t *testing.T) {
+	ep1 := &endpointMetadata{
+		id:     endpointID("endpoint-1"),
+		ip:     netip.MustParseAddr("10.0.0.10"),
+		labels: map[string]string{"app": "web"},
+	}
+	ep2 := &endpointMetadata{
+		id:     endpointID("endpoint-2"),
+		ip:     netip.MustParseAddr("10.0.0.20"),
+		labels: map[string]string{"app": "api"},
+	}
+
+	tests := []struct {
+		name      string
+		eps       map[endpointID]*endpointMetadata
+		svcs      map[serviceID]*serviceMetadata
+		wantRules map[crap.CrapKey]crap.CrapVal
+	}{
+		{
+			name: "matching service with multiple VIPs",
+			eps:  map[endpointID]*endpointMetadata{ep1.id: ep1, ep2.id: ep2},
+			svcs: map[serviceID]*serviceMetadata{
+				serviceID("svc-1"): {
+					id:     serviceID("svc-1"),
+					labels: map[string]string{"app": "web"},
+					vip:    []netip.Addr{netip.MustParseAddr("203.0.113.1"), netip.MustParseAddr("203.0.113.2")},
+				},
+			},
+			wantRules: map[crap.CrapKey]crap.CrapVal{
+				crap.NewKey(netip.MustParseAddr("203.0.113.1")): crap.NewVal(ep1.ip),
+				crap.NewKey(netip.MustParseAddr("203.0.113.2")): crap.NewVal(ep1.ip),
+			},
+		},
+		{
+			name: "no matching endpoint produces no rules",
+			eps:  map[endpointID]*endpointMetadata{ep2.id: ep2},
+			svcs: map[serviceID]*serviceMetadata{
+				serviceID("svc-1"): {
+					id:     serviceID("svc-1"),
+					labels: map[string]string{"app": "web"},
+					vip:    []netip.Addr{netip.MustParseAddr("203.0.113.1")},
+				},
+			},
+			wantRules: map[crap.CrapKey]crap.CrapVal{},
+		},
+		{
+			name: "empty selector matches nothing",
+			eps:  map[endpointID]*endpointMetadata{ep1.id: ep1},
+			svcs: map[serviceID]*serviceMetadata{
+				serviceID("svc-1"): {
+					id:     serviceID("svc-1"),
+					labels: map[string]string{},
+					vip:    []netip.Addr{netip.MustParseAddr("203.0.113.1")},
+				},
+			},
+			wantRules: map[crap.CrapKey]crap.CrapVal{},
+		},
+		{
+			name:      "no services produces no rules",
+			eps:       map[endpointID]*endpointMetadata{ep1.id: ep1},
+			svcs:      map[serviceID]*serviceMetadata{},
+			wantRules: map[crap.CrapKey]crap.CrapVal{},
+		},
+		{
+			name: "no endpoints produces no rules",
+			eps:  map[endpointID]*endpointMetadata{},
+			svcs: map[serviceID]*serviceMetadata{
+				serviceID("svc-1"): {
+					id:     serviceID("svc-1"),
+					labels: map[string]string{"app": "web"},
+					vip:    []netip.Addr{netip.MustParseAddr("203.0.113.1")},
+				},
+			},
+			wantRules: map[crap.CrapKey]crap.CrapVal{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildRules(tt.eps, tt.svcs)
+			assert.Equal(t, tt.wantRules, got)
+		})
+	}
+}


### PR DESCRIPTION
  ## Summary

  Add targeted test coverage for the new CRAP datapath pieces in pkg/maps/crap and pkg/raw.

  This closes the main gaps around:

  - CRAP map helper behavior and cell wiring
  - real BPF map CRUD coverage
  - RAW rule construction logic
  - reconciliation behavior for adding, updating, and removing map entries

  ## Verification

  From the repo root:

  go test ./pkg/maps/crap ./pkg/raw -count=1
  make tests-privileged-only