### PR TITLE
operator: allow explicit 0 to disable Proxy{Idle,StreamIdle}TimeoutSeconds

### DIFF
--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -412,11 +412,11 @@ func (c *OperatorConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.LeaderElectionRetryPeriod = vp.GetDuration(LeaderElectionRetryPeriod)
 	c.EnableGatewayAPI = vp.GetBool(EnableGatewayAPI)
 	c.ProxyIdleTimeoutSeconds = vp.GetInt(ProxyIdleTimeoutSeconds)
-	if c.ProxyIdleTimeoutSeconds == 0 {
+	if !vp.IsSet(ProxyIdleTimeoutSeconds) {
 		c.ProxyIdleTimeoutSeconds = DefaultProxyIdleTimeoutSeconds
 	}
 	c.ProxyStreamIdleTimeoutSeconds = vp.GetInt(ProxyStreamIdleTimeoutSeconds)
-	if c.ProxyStreamIdleTimeoutSeconds == 0 {
+	if !vp.IsSet(ProxyStreamIdleTimeoutSeconds) {
 		c.ProxyStreamIdleTimeoutSeconds = DefaultProxyStreamIdleTimeoutSeconds
 	}
 	c.CiliumPodLabels = vp.GetString(CiliumPodLabels)


### PR DESCRIPTION
## Summary

`operator/option/config.go` rewrites `ProxyIdleTimeoutSeconds` and `ProxyStreamIdleTimeoutSeconds` back to their defaults (`60s` / `300s`) whenever the loaded value is `0`. This conflates "the key was not set" with "the user explicitly set 0", and there's no way to express "disabled" through the Helm chart (or any other config surface) because the value silently snaps back.

Envoy documents `0` as the sentinel for "disabled" on these fields (`common_http_protocol_options.idle_timeout`, HCM `stream_idle_timeout`), so this is the natural value users will try.

This PR swaps `== 0` for `!vp.IsSet(...)`. The default still applies when the key is truly absent (direct binary invocation without Helm), but explicit `0` now flows through.

```diff
 c.ProxyIdleTimeoutSeconds = vp.GetInt(ProxyIdleTimeoutSeconds)
-if c.ProxyIdleTimeoutSeconds == 0 {
+if !vp.IsSet(ProxyIdleTimeoutSeconds) {
     c.ProxyIdleTimeoutSeconds = DefaultProxyIdleTimeoutSeconds
 }
 c.ProxyStreamIdleTimeoutSeconds = vp.GetInt(ProxyStreamIdleTimeoutSeconds)
-if c.ProxyStreamIdleTimeoutSeconds == 0 {
+if !vp.IsSet(ProxyStreamIdleTimeoutSeconds) {
     c.ProxyStreamIdleTimeoutSeconds = DefaultProxyStreamIdleTimeoutSeconds
 }
```

## How we hit this

A gRPC long-lived server-streaming RPC routed through Cilium's Gateway API (`cf-tunnel` Gateway → upstream Service with `appProtocol: kubernetes.io/h2c`) reset every 60 seconds with `RST_STREAM` `INTERNAL_ERROR`. The client's only keepalive traffic is HTTP/2 PING frames, which terminate at cilium-envoy. From the upstream connection's perspective there is no DATA traffic, so the upstream `idle_timeout: 60s` on the cluster fires and Envoy tears the stream down.

Setting `envoy.idleTimeoutDurationSeconds: 0` in the Helm chart looked correct end-to-end:

- `cilium-config` ConfigMap: `proxy-idle-timeout-seconds: "0"` ✅
- cilium-envoy bootstrap clusters (`ingress-cluster`, `egress-cluster`, …): `idleTimeout: 0s` ✅
- But the **Gateway API CiliumEnvoyConfig** still had `idleTimeout: 60s` on every upstream cluster ❌

That asymmetry is exactly because `cilium-agent` and `cilium-operator` consume `proxy-idle-timeout-seconds` through different code paths. cilium-agent (`pkg/envoy/...`) honors `0`. cilium-operator (`operator/option/config.go`) coerces it back to 60 before passing it to the Gateway API and Ingress translators (`operator/pkg/gateway-api/cell.go:250`, `operator/pkg/ingress/cell.go:125`), and those then bake the wrong value into every generated CEC.

Confirmed causally on a running cluster:
- `envoy_cluster_upstream_cx_idle_timeout` on the matching cluster incremented one cycle per ~60s while neighbor clusters stayed at zero.
- Tracing the value `60s` through the dump:
  `configs.1.dynamic_active_clusters.N.cluster.typed_extension_protocol_options.envoy.extensions.upstreams.http.v3.HttpProtocolOptions.common_http_protocol_options.idle_timeout`
- Forcing a CEC re-reconcile (via annotation bump on the Gateway, and via `kubectl rollout restart deploy/cilium-operator`) did not change the value — operator's desired spec is still `60s` because of the coercion.

## Backward compatibility

The existing Helm chart sets `idleTimeoutDurationSeconds: 60` as a default in `install/kubernetes/cilium/values.yaml`, so the rendered `cilium-config` ConfigMap always carries a value. For any Helm-managed deployment behavior is unchanged: a user who hasn't overridden the value continues to get `60s`. The change only affects users who explicitly set `0` (currently silently broken) or any other value that happens to be `0`.

For non-Helm callers that invoke `cilium-operator` directly without setting this key, `vp.IsSet` returns false and the existing default (`DefaultProxyIdleTimeoutSeconds = 60`) applies.

## Tests

```
$ go build ./operator/option/...           # clean
$ go test ./operator/option/...            # no test files
$ go test ./operator/pkg/gateway-api/...   # ok
```

## Notes

- A stopgap on the platform side uses `idleTimeoutDurationSeconds: 86400` (24h) while this lands.
- The same `== 0` pattern in `cilium-agent`'s upstream config (`pkg/envoy/config/config.go` and friends) is correctly handled — only the operator-side path has this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)